### PR TITLE
Modify emit_dict to include symbols when b is empty

### DIFF
--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 import sys
 import json
@@ -84,7 +84,7 @@ class CompactJsonDiffSyntax(object):
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
         if s == 0.0:
             return {replace: b} if isinstance(b, dict) else b
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -97,7 +97,7 @@ class CompactJsonDiffSyntax(object):
     def emit_dict_diff(self, a, b, s, added, changed, removed):
         if s == 0.0:
             return {replace: b} if isinstance(b, dict) else b
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             changed.update(added)
@@ -171,9 +171,9 @@ class ExplicitJsonDiffSyntax(object):
             return d
 
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
-        if s == 0.0:
+        if s == 0.0 and not (inserted or changed or deleted):
             return b
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -184,9 +184,9 @@ class ExplicitJsonDiffSyntax(object):
             return d
 
     def emit_dict_diff(self, a, b, s, added, changed, removed):
-        if s == 0.0:
+        if s == 0.0 and not (added or changed or removed):
             return b
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             d = {}
@@ -218,9 +218,9 @@ class SymmetricJsonDiffSyntax(object):
             return d
 
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
-        if s == 0.0:
+        if s == 0.0 and not (inserted or changed or deleted):
             return [a, b]
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -231,9 +231,9 @@ class SymmetricJsonDiffSyntax(object):
             return d
 
     def emit_dict_diff(self, a, b, s, added, changed, removed):
-        if s == 0.0:
+        if s == 0.0 and not (added or changed or removed):
             return [a, b]
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             d = changed

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -128,3 +128,39 @@ class JsonDiffTests(unittest.TestCase):
             self.fail('cannot diff long arrays')
         finally:
             sys.setrecursionlimit(r)
+
+    def test_remove_all_items_from_list(self):
+        """
+        Remove the final item in a list and confirm that the resulting diff using explicit syntax
+        shows the deleted items.
+        :return:
+        """
+        a_list = ['x', 'y', 'z']
+        z_list = ['z']
+
+        self.assertEqual({'$delete': [1, 0]}, diff(a_list, z_list, syntax='compact', marshal=True))
+        self.assertEqual([], diff(a_list, [], syntax='compact', marshal=True))
+
+        self.assertEqual({'$delete': [1, 0]}, diff(a_list, z_list, syntax='explicit', marshal=True))
+        self.assertEqual({'$delete': [2, 1, 0]}, diff(a_list, [], syntax='explicit', marshal=True))
+
+        self.assertEqual({'$delete': [(1, 'y'), (0, 'x')]}, diff(a_list, z_list, syntax='symmetric', marshal=True))
+        self.assertEqual({'$delete': [(2, 'z'), (1, 'y'), (0, 'x')]}, diff(a_list, [], syntax='symmetric', marshal=True))
+
+    def test_remove_all_items_from_dict(self):
+        """
+        Remove the final item in a dict and confirm that the resulting diff using explicit syntax
+        shows the deleted items.
+        :return:
+            """
+        b_dict = {'a_key': 1, 'b_key': 2, 'c_key': 3}
+        c_dict = {'c_key': 3}
+
+        self.assertEqual({'$delete': ['a_key', 'b_key']}, diff(b_dict, c_dict, syntax='compact', marshal=True))
+        self.assertEqual({'$replace': {}}, diff(b_dict, {}, syntax='compact', marshal=True))
+
+        self.assertEqual({'$delete': ['a_key', 'b_key']}, diff(b_dict, c_dict, syntax='explicit', marshal=True))
+        self.assertEqual({'$delete': ['a_key', 'b_key', 'c_key']}, diff(b_dict, {}, syntax='explicit', marshal=True))
+
+        self.assertEqual({'$delete': {'a_key': 1, 'b_key': 2}}, diff(b_dict, c_dict, syntax='symmetric', marshal=True))
+        self.assertEqual({'$delete': {'a_key': 1, 'b_key': 2, 'c_key': 3}}, diff(b_dict, {}, syntax='symmetric', marshal=True))


### PR DESCRIPTION
If only removals occurred, 'smatched' is never incremented defaulting s==1. To print the entire list of changes, also check for whether any changes occurred before returning an empty dict.