### PR TITLE
Clarify readme to include "marshal=True"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,12 @@ Quickstart
     >>> print diff('["a", "b", "c"]', '["a", "c", "d"]', load=True, dump=True)
     {"$delete": [1], "$insert": [[2, "d"]]}
 
+    # Note: the entity returned by `diff` keynames are not able accessed
+    # if you want to access the diff as a dictionary, pass the `marshal=True` option like so: 
+    >>> difference = diff({"a": 1, "b": 2}, {"b": 3, "c": 4}, marshal=True) # {"$insert": {"c": 4}, "$update": {"b: 3}, "$delete": ["a"]}
+    >>> dictionary_diff = difference.get('$update') 
+    {"b": 3}
+    
 
 Command Line Client
 -------------------


### PR DESCRIPTION
I spent a fair amount of time to figure this out, along with a few others who have posted similar questions in the issues. 

https://github.com/xlwings/jsondiff/issues/23

It isn't exactly clear that `diff` by default does not provide you with key-names that you can use, so this will help people save some time by knowing that the `marshal` option seems to exist for this purpose.

