### PR TITLE
Remove deprecated jsondiff entry point.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'jsondiff=jsondiff.cli:main_deprecated',
             'jdiff=jsondiff.cli:main'
         ]
     }


### PR DESCRIPTION
The `jsondiff` entry point was deprecated 3 years ago, and is still causing conflicts with jsonpatch.

I don't know what your versioning requirements are for removing deprecations, but I thought I'd drop a PR.

Thanks!

