### PR TITLE
Added simple equality operator for class Symbol

### DIFF
--- a/jsondiff/symbols.py
+++ b/jsondiff/symbols.py
@@ -9,6 +9,9 @@ class Symbol(object):
     def __str__(self):
         return "$" + self.label
 
+    def __eq__(self, other):
+        return self.label == other.label
+
 missing = Symbol('missing')
 identical = Symbol('identical')
 delete = Symbol('delete')


### PR DESCRIPTION
Following on my [issue regarding the implementation of the equality operator](https://github.com/xlwings/jsondiff/issues/54), I did just that.
This now allows equality comparison between two `Symbol` instances and returns `True` if their `label` attributes are equal.