### PR TITLE
jsondiff: fix symbol equality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target/
 
 # PyCharm
 .idea
+
+.hypothesis/

--- a/jsondiff/symbols.py
+++ b/jsondiff/symbols.py
@@ -1,7 +1,11 @@
 
 class Symbol(object):
     def __init__(self, label):
-        self.label = label
+        self._label = label
+
+    @property
+    def label(self):
+        return self._label
 
     def __repr__(self):
         return self.label
@@ -11,6 +15,9 @@ class Symbol(object):
 
     def __eq__(self, other):
         return self.label == other.label
+    
+    def __hash__(self) -> int:
+        return hash(self.label)
 
 missing = Symbol('missing')
 identical = Symbol('identical')


### PR DESCRIPTION
In #55 an equality method was introduced without a corresponding hash
method. Hashable objects that implement `__eq__` must also implement
`__hash__` if the type is immutable [1]. Implement hash using the label
field which is now a property in order to convey the intent of
immutability.

Fixes #58

[1] https://docs.python.org/3/reference/datamodel.html#object.__hash__

Signed-off-by: Cory Todd <cory.todd@canonical.com>