### PR TITLE
symbols: fix python 2 compat

### DIFF
--- a/jsondiff/symbols.py
+++ b/jsondiff/symbols.py
@@ -16,7 +16,7 @@ class Symbol(object):
     def __eq__(self, other):
         return self.label == other.label
     
-    def __hash__(self) -> int:
+    def __hash__(self):
         return hash(self.label)
 
 missing = Symbol('missing')


### PR DESCRIPTION
Remove type hint that breaks Python 2.x support.

But... is Python 2 support really worth maintaining at this point?