### PR TITLE
fix: better diffing of empty containers

### DIFF
--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -84,7 +84,7 @@ class CompactJsonDiffSyntax(object):
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
         if s == 0.0:
             return {replace: b} if isinstance(b, dict) else b
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -97,7 +97,7 @@ class CompactJsonDiffSyntax(object):
     def emit_dict_diff(self, a, b, s, added, changed, removed):
         if s == 0.0:
             return {replace: b} if isinstance(b, dict) else b
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             changed.update(added)
@@ -171,9 +171,9 @@ class ExplicitJsonDiffSyntax(object):
             return d
 
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
-        if s == 0.0:
+        if s == 0.0 and not (inserted or changed or deleted):
             return b
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -184,9 +184,9 @@ class ExplicitJsonDiffSyntax(object):
             return d
 
     def emit_dict_diff(self, a, b, s, added, changed, removed):
-        if s == 0.0:
+        if s == 0.0 and not (added or changed or removed):
             return b
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             d = {}
@@ -218,9 +218,9 @@ class SymmetricJsonDiffSyntax(object):
             return d
 
     def emit_list_diff(self, a, b, s, inserted, changed, deleted):
-        if s == 0.0:
+        if s == 0.0 and not (inserted or changed or deleted):
             return [a, b]
-        elif s == 1.0:
+        elif s == 1.0 and not (inserted or changed or deleted):
             return {}
         else:
             d = changed
@@ -231,9 +231,9 @@ class SymmetricJsonDiffSyntax(object):
             return d
 
     def emit_dict_diff(self, a, b, s, added, changed, removed):
-        if s == 0.0:
+        if s == 0.0 and not (added or changed or removed):
             return [a, b]
-        elif s == 1.0:
+        elif s == 1.0 and not (added or changed or removed):
             return {}
         else:
             d = changed

--- a/tests/test_jsondiff.py
+++ b/tests/test_jsondiff.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import pytest
 
 from jsondiff import diff, replace, add, discard, insert, delete, update, JsonDiffer
 
@@ -134,3 +135,30 @@ class JsonDiffTests(unittest.TestCase):
             self.fail('cannot diff long arrays')
         finally:
             sys.setrecursionlimit(r)
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "syntax", "expected"),
+    [
+        pytest.param([], [{"a": True}], "explicit", {insert: [(0, {"a": True})]},
+                     id="issue59_"),
+        pytest.param([{"a": True}], [], "explicit", {delete: [0]},
+                     id="issue59_"),
+        pytest.param([], [{"a": True}], "compact", [{"a": True}],
+                     id="issue59_"),
+        pytest.param([{"a": True}], [], "compact", [],
+                     id="issue59_"),
+        pytest.param([], [{"a": True}], "symmetric", {insert: [(0, {"a": True})]},
+                     id="issue59_"),
+        pytest.param([{"a": True}], [], "symmetric", {delete: [(0, {"a": True})]},
+                     id="issue59_"),
+        pytest.param({1: 2}, {5: 3}, "symmetric", {delete: {1: 2}, insert: {5: 3}},
+                     id="issue36_"),
+        pytest.param({1: 2}, {5: 3}, "compact", {replace: {5: 3}},
+                     id="issue36_"),
+    ],
+)
+class TestSpecificIssue:
+    def test_issue(self,  a, b, syntax, expected):
+        actual = diff(a, b, syntax=syntax)
+        assert actual == expected


### PR DESCRIPTION
This is a forward port of [1] kivattik/master excluding changes to tests. The original
authorship of @kivattik has been preserved in the commit which was proposed in #38 . 

This fixes #36 and #59 

[1] 92e4da3 ("Modify emit_dict to include symbols when b is empty")