### PR TITLE
setup.py: migrate to pyproject.toml

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
-          pip install -r dev-requirements.txt
+          pip install .[test]
       - name: Run Tests
         run: |
           python -m pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,0 @@
-hypothesis
-pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=43.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jsondiff"
+description = "Diff JSON and JSON-like structures in Python"
+dynamic = ["version"]
+readme = "README.rst"
+license= {file = "LICENSE" }
+requires-python = ">=3.8"
+authors = [
+    { name = "Zoomer Analytics LLC", email = "eric.reynolds@zoomeranalytics.com"}
+]
+keywords = ['json', 'diff', 'diffing', 'difference', 'patch', 'delta', 'dict', 'LCS']
+classifiers = [
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 3',
+]
+
+[project.optional-dependencies]
+test = [
+    "hypothesis",
+    "pytest"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/xlwings/jsondiff"
+"Bug Tracker" = "https://github.com/xlwings/jsondiff/issues"
+
+[project.scripts]
+jdiff = "jsondiff.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["jsondiff*"]
+exclude = ["tests*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "jsondiff.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,4 @@
-import os
-import re
-from setuptools import setup, find_packages
+# Maintained for legacy compatibility
+from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), 'jsondiff', '__init__.py')) as f:
-    version = re.compile(r".*__version__ = '(.*?)'", re.S).match(f.read()).group(1)
-
-setup(
-    name='jsondiff',
-    packages=find_packages(exclude=['tests']),
-    version=version,
-    description='Diff JSON and JSON-like structures in Python',
-    author='Zoomer Analytics LLC',
-    author_email='eric.reynolds@zoomeranalytics.com',
-    url='https://github.com/ZoomerAnalytics/jsondiff',
-    keywords=['json', 'diff', 'diffing', 'difference', 'patch', 'delta', 'dict', 'LCS'],
-    classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-    ],
-    entry_points={
-        'console_scripts': [
-            'jdiff=jsondiff.cli:main'
-        ]
-    }
-)
+setup()


### PR DESCRIPTION
Embrace the PEP5158 standard but keep on using setuptools. Building is done the same way (python -sBm build) so there are no functional changes to the build artifacts. The motivation for this change is that switching to another build system in future is trivial when using PEP518. An added bonus is this file integrates nicely with linters and formatters as well.

This should help with #47 .

---

I'm not sure what the maintainer's build/release process looks like so let me know if this breaks the workflow, I'm happy to iterate on this.