### PR TITLE
Make list diff reuse _obj_diff results instead of making duplicate calls

### DIFF
--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -468,12 +468,12 @@ class JsonDiffer(object):
             for symbol in _all_symbols_
         }
 
-    def _list_diff_0(self, C, X, Y):
+    def _list_diff_0(self, C, X, Y, similarity):
         i, j = len(X), len(Y)
         r = []
         while True:
             if i > 0 and j > 0:
-                d, s = self._obj_diff(X[i-1], Y[j-1])
+                d, s = similarity[i-1][j-1]
                 if s > 0 and C[i][j] == C[i-1][j-1] + s:
                     r.append((0, d, j-1, s))
                     i, j = i - 1, j - 1
@@ -494,9 +494,12 @@ class JsonDiffer(object):
         n = len(Y)
         # An (m+1) times (n+1) matrix
         C = [[0 for j in range(n+1)] for i in range(m+1)]
+        similarity = [[0 for j in range(n)] for i in range(m)]
         for i in range(1, m+1):
             for j in range(1, n+1):
-                _, s = self._obj_diff(X[i-1], Y[j-1])
+                child_diff = self._obj_diff(X[i-1], Y[j-1])
+                similarity[i-1][j-1] = child_diff
+                s = child_diff[1]
                 # Following lines are part of the original LCS algorithm
                 # left in the code in case modification turns out to be problematic
                 #if X[i-1] == Y[j-1]:
@@ -508,7 +511,7 @@ class JsonDiffer(object):
         changed = {}
         tot_s = 0.0
 
-        for sign, value, pos, s in self._list_diff_0(C, X, Y):
+        for sign, value, pos, s in self._list_diff_0(C, X, Y, similarity):
             if sign == 1:
                 inserted.append((pos, value))
             elif sign == -1:


### PR DESCRIPTION
The backtracking pass of the list diff algorithm in `_list_diff_0` was calling `_obj_diff` on pairs of objects that had already been diffed in the forward pass earlier in the `_list_diff` method.

When I create an array of `_obj_diff` results in the forward pass and reuse that array in the backtracking pass, I see about a 5x speedup on JSON files that contain lists of a few dozen large objects.