### PR TITLE
ci: upload to pypi on github release

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -1,0 +1,32 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ target/
 .idea
 
 .hypothesis/
+
+# Ignore auto-generated _version
+/jsondiff/_version.py

--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -1,5 +1,3 @@
-__version__ = '2.0.0'
-
 import sys
 import json
 import yaml
@@ -9,6 +7,7 @@ from yaml import YAMLError
 
 from .symbols import *
 from .symbols import Symbol
+from ._version import __version__
 
 # rules
 # - keys and strings which start with $ (or specified escape_str) are escaped to $$ (or escape_str * 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=64.0.0", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -30,8 +30,10 @@ include = ["jsondiff*"]
 exclude = ["tests*"]
 
 [tool.setuptools.dynamic]
-version = {attr = "jsondiff.__version__"}
 dependencies = {file=["requirements.txt"]}
+
+[tool.setuptools_scm]
+version_file = "jsondiff/_version.py"
 
 [tool.setuptools.dynamic.optional-dependencies]
 dev = {file=["requirements-dev.txt"]}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 hypothesis
 pytest
 setuptools-scm
+build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 hypothesis
 pytest
+setuptools-scm


### PR DESCRIPTION
Use pypi github action to upload the artifact of a build. A tag must be present on the commit being built which a normal
Github Release should provide. We can also add an on tag push trigger if that helps.

I tested this on my fork by adding an upload artifact step, downloading the wheel, and installing in a venv. The version
reports correctly and the cli tool runs as expected. If possible, it might be nice to publish to a pypi dev first to make sure
other people can test it.

Fixes #75