### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # jsondiff documentation build configuration file, created by
 # sphinx-quickstart on Fri Nov 13 17:39:49 2015.
@@ -46,9 +45,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'jsondiff'
-copyright = u'2015, Eric Reynolds'
-author = u'Eric Reynolds'
+project = 'jsondiff'
+copyright = '2015, Eric Reynolds'
+author = 'Eric Reynolds'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -222,8 +221,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'jsondiff.tex', u'jsondiff Documentation',
-   u'Eric Reynolds', 'manual'),
+  (master_doc, 'jsondiff.tex', 'jsondiff Documentation',
+   'Eric Reynolds', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -266,7 +265,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'jsondiff', u'jsondiff Documentation',
+  (master_doc, 'jsondiff', 'jsondiff Documentation',
    author, 'jsondiff', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -24,7 +24,7 @@ else:
     string_types = basestring
 
 
-class JsonDumper(object):
+class JsonDumper:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 
@@ -38,7 +38,7 @@ class JsonDumper(object):
 default_dumper = JsonDumper()
 
 
-class YamlDumper(object):
+class YamlDumper:
     """Write object as YAML string"""
 
     def __init__(self, **kwargs):
@@ -52,7 +52,7 @@ class YamlDumper(object):
         """
         return yaml.dump(obj, dest, **self.kwargs)
 
-class JsonLoader(object):
+class JsonLoader:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 
@@ -70,7 +70,7 @@ class JsonLoader(object):
 default_loader = JsonLoader()
 
 
-class YamlLoader(object):
+class YamlLoader:
     """Load YAML data from file-like object or string"""
 
     def __call__(self, src):
@@ -121,7 +121,7 @@ class Serializer:
         dumper(obj, stream)
 
 
-class JsonDiffSyntax(object):
+class JsonDiffSyntax:
     def emit_set_diff(self, a, b, s, added, removed):
         raise NotImplementedError()
 
@@ -141,7 +141,7 @@ class JsonDiffSyntax(object):
         raise NotImplementedError()
 
 
-class CompactJsonDiffSyntax(object):
+class CompactJsonDiffSyntax:
     def emit_set_diff(self, a, b, s, added, removed):
         if s == 0.0 or len(removed) == len(a):
             return {replace: b} if isinstance(b, dict) else b
@@ -230,7 +230,7 @@ class CompactJsonDiffSyntax(object):
         return d
 
 
-class ExplicitJsonDiffSyntax(object):
+class ExplicitJsonDiffSyntax:
     def emit_set_diff(self, a, b, s, added, removed):
         if s == 0.0 or len(removed) == len(a):
             return b
@@ -277,7 +277,7 @@ class ExplicitJsonDiffSyntax(object):
             return b
 
 
-class SymmetricJsonDiffSyntax(object):
+class SymmetricJsonDiffSyntax:
     def emit_set_diff(self, a, b, s, added, removed):
         if s == 0.0 or len(removed) == len(a):
             return [a, b]
@@ -447,9 +447,9 @@ builtin_syntaxes = {
 }
 
 
-class JsonDiffer(object):
+class JsonDiffer:
 
-    class Options(object):
+    class Options:
         pass
 
     def __init__(self, syntax='compact', load=False, dump=False, marshal=False,

--- a/jsondiff/cli.py
+++ b/jsondiff/cli.py
@@ -3,7 +3,7 @@ import jsondiff
 import sys
 
 def load_file(serializer, file_path):
-    with open(file_path, "r") as f:
+    with open(file_path) as f:
         parsed = None
         try:
             parsed = serializer.deserialize_file(f)

--- a/jsondiff/symbols.py
+++ b/jsondiff/symbols.py
@@ -1,5 +1,4 @@
-
-class Symbol(object):
+class Symbol:
     def __init__(self, label):
         self._label = label
 

--- a/tests/generate_readme.py
+++ b/tests/generate_readme.py
@@ -1,6 +1,5 @@
 # this is used for generating the repo front page
 
-from __future__ import print_function
 
 def do(cmd, comment=None):
     if comment:

--- a/tests/test_jsondiff.py
+++ b/tests/test_jsondiff.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 
 import jsondiff
-from jsondiff import diff, replace, add, discard, insert, delete, update, JsonDiffer
+from jsondiff import diff, replace, add, discard, insert, delete, JsonDiffer
 
 from .utils import generate_random_json, perturbate_json
 


### PR DESCRIPTION
Filter all codede over `pyupgrade --py38-plus`.