### PR TITLE
Protect Symbol.__eq__ by instance check.

### DIFF
--- a/jsondiff/symbols.py
+++ b/jsondiff/symbols.py
@@ -36,8 +36,10 @@ class Symbol:
         return "$" + self.label
 
     def __eq__(self, other):
+        if not isinstance(other, Symbol):
+            return False
         return self.label == other.label
-    
+
     def __hash__(self) -> int:
         return hash(self.label)
 


### PR DESCRIPTION
This avoids an AttributeError when comparing to other objects.