### PR TITLE
fix(cli): allow empty dicts/lists as valid input arguments

### DIFF
--- a/jsondiff/cli.py
+++ b/jsondiff/cli.py
@@ -33,7 +33,7 @@ def main():
     parsed_first = load_file(serializer, args.first)
     parsed_second = load_file(serializer, args.second)
 
-    if not (parsed_first and parsed_second):
+    if parsed_first is None or parsed_second is None:
         return 1
 
     if args.patch:


### PR DESCRIPTION
## Summary

The CLI guard `not (parsed_first and parsed_second)` on line 36 of `cli.py` wrongly exits when either argument is a valid but falsy JSON value such as `{}`, `[]`, `0`, `""`, or `false`.

Python treats empty dicts and lists as falsy, so `not (parsed_first and parsed_second)` evaluates to `True` for inputs like `jdiff <(echo '{"a":1}') <(echo '{}')`, causing the tool to exit with code 1 and no output instead of producing `{"$delete": ["a"]}`.

**Fix:** Replace the falsiness check with explicit `is None` comparisons so only actual load failures (where `load_file()` returns `None`) cause early exit.

Fixes #87

## Test plan

- [x] `jdiff -s explicit <(echo '{"a":1}') <(echo '{}')` now outputs `{"$delete": ["a"]}` (was silent)
- [x] `jdiff -s explicit <(echo '{}') <(echo '{"a":1}')` now outputs `{"$insert": {"a": 1}}` (was silent)
- [x] `jdiff <(echo '[]') <(echo '1')` now outputs `1` (was silent)
- [x] Normal cases with non-empty dicts still work correctly
- [x] All 26 existing tests pass

---

*This contribution was made with AI assistance under my direction.*